### PR TITLE
Fix alert dialog triggers to avoid nested buttons

### DIFF
--- a/components/deleteDialog/index.tsx
+++ b/components/deleteDialog/index.tsx
@@ -23,7 +23,7 @@ export default function DeleteDialog({
 }: DeleteDialogProps) {
   return (
     <AlertDialog>
-      <AlertDialogTrigger>
+      <AlertDialogTrigger asChild>
         <Button variant="ghost" size="icon">
           <Trash2 className="h-4 w-4" />
         </Button>

--- a/components/updateDialog/index.tsx
+++ b/components/updateDialog/index.tsx
@@ -33,7 +33,7 @@ export default function UpdateDialog({
 }: DeleteDialogProps) {
   return (
     <AlertDialog>
-      <AlertDialogTrigger>
+      <AlertDialogTrigger asChild>
         <Button variant="ghost" size="icon">
           <Edit2 className="h-4 w-4" />
         </Button>
@@ -90,7 +90,7 @@ export function UpdateQuestionaryDialog({
 
   return (
     <AlertDialog>
-      <AlertDialogTrigger>
+      <AlertDialogTrigger asChild>
         <Button variant="ghost" size="icon">
           <Edit2 className="h-4 w-4" />
         </Button>


### PR DESCRIPTION
## Summary
- add `asChild` to the delete and update dialog triggers so the buttons are rendered directly

## Testing
- npm run lint *(fails: existing prettier / eslint violations in unrelated ui component files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691227425bec832ab4a9ecd5d1cd4c91)